### PR TITLE
Rework spin-redirect to Non-WAGI & support for custom status codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ENABLE_WASM_OPT ?= true
 
 .PHONY: build
 build:
-	tinygo build -wasm-abi=generic -target=wasi -gc=leaking -o redirect.wasm redirect.go
+	tinygo build -target=wasi -gc=leaking -o redirect.wasm ./
 ifeq ($(ENABLE_WASM_OPT),true)
 	wasm-opt -Os -o redirect.wasm redirect.wasm
 endif

--- a/README.md
+++ b/README.md
@@ -15,10 +15,20 @@ The following table outlines available configuration values:
 
 | Key           | Description                                           | Default Value    |
 |---------------|-------------------------------------------------------|------------------|
-| `destination` | Where should the component redirect to                | *(empty string)* |
+| `destination` | Where should the component redirect to                | `/`              |
 | `statuscode`  | What HTTP status code should be used when redirecting | `302`            |
 
 The `spin-redirect` component tries to look up the config value in the Spin component configuration using the keys shown in the table above (lower case). If desired key is not present, it transforms the key to upper case (e.g., `DESTINATION`) and checks environment variables.
+
+### Valid redirection status codes
+
+The `spin-redirect` component supports the following HTTP status codes to perform a redirect:
+
+- `301` Moved Permanently
+- `302` Found (Moved Temporarily)
+- `303` See Other: Only supported for `PUT` and `POST` requests
+- `307` Temporary Redirect
+- `308` Permanent Redirect
 
 ## Example usage
 
@@ -54,9 +64,11 @@ version = "0.1.0"
 [[component]]
 id = "redirect-sample"
 source = "path/to/redirect.wasm"
+
 [component.config]
 destination="/index.html"
 statuscode="301"
+
 [component.trigger]
 route = "/"
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,60 @@ This is a simple HTTP redirect component written in Go.
 
 This is not a Spin application in itself but a component that can be used in applications to redirect a route.
 
-Example usage:
+## Configuration
 
-```
-# Redirect / to /index.html
+The `spin-redirect` component can be configured to address your needs in different scenarios. `spin-redirect` tries to load configuration data from multiple places in the specified order:
+
+1. Spin component configuration
+2. Environment variables
+
+The following table outlines available configuration values:
+
+| Key           | Description                                           | Default Value    |
+|---------------|-------------------------------------------------------|------------------|
+| `destination` | Where should the component redirect to                | *(empty string)* |
+| `statuscode`  | What HTTP status code should be used when redirecting | `302`            |
+
+The `spin-redirect` component tries to lookup the config value in the Spin component configuration using the keys shown in the table above (lower case). If desired key is not present, it tries transforms the key to upper case (e.g., `DESTINATION`) and checks environment variables.
+
+## Example usage
+
+The following snippet shows how to add and configure `spin-redirect` in your `spin.toml` using environment variables
+
+```toml
+spin_manifest_version = "1"
+description = ""
+name = "test"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+# Redirect / to /index.html using HTTP status code 301
 [[component]]
-id = "redirect-to-index"
+id = "redirect-sample"
 source = "path/to/redirect.wasm"
-environment = { DESTINATION = "/index.html" }
+environment = { DESTINATION = "/index.html", STATUSCODE = "301" }
+
 [component.trigger]
 route = "/"
-executor = { type = "wagi" }
+```
+
+Alternatively, you can use component configuration to configure `spin-redirect` as shown below:
+
+```toml
+spin_manifest_version = "1"
+description = ""
+name = "test"
+trigger = { type = "http", base = "/" }
+version = "0.1.0"
+
+# Redirect / to /index.html using HTTP status code 301
+[[component]]
+id = "redirect-sample"
+source = "path/to/redirect.wasm"
+[component.config]
+destination="/index.html"
+statuscode="301"
+[component.trigger]
+route = "/"
+
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The following table outlines available configuration values:
 | `destination` | Where should the component redirect to                | *(empty string)* |
 | `statuscode`  | What HTTP status code should be used when redirecting | `302`            |
 
-The `spin-redirect` component tries to lookup the config value in the Spin component configuration using the keys shown in the table above (lower case). If desired key is not present, it tries transforms the key to upper case (e.g., `DESTINATION`) and checks environment variables.
+The `spin-redirect` component tries to look up the config value in the Spin component configuration using the keys shown in the table above (lower case). If desired key is not present, it transforms the key to upper case (e.g., `DESTINATION`) and checks environment variables.
 
 ## Example usage
 

--- a/config.go
+++ b/config.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"strings"
+
+	config "github.com/fermyon/spin/sdk/go/config"
+)
+
+type ConfigReader interface {
+	Get(key string) string
+}
+
+/*
+DefaultConfigReader implements ConfigReader interface
+and provides a Get method for reading configuration values.
+
+It first tries to find the value in Spin configuration.
+If the key is not found in Spin configuration, it will try
+to find the value in the environment variables.
+*/
+type DefaultConfigReader struct{}
+
+// NewDefaultConfigReader returns a new DefaultConfigReader
+func NewDefaultConfigReader() DefaultConfigReader {
+	return DefaultConfigReader{}
+}
+
+/*
+Get returns the configuration value for the given key
+If the key is not found in Spin configuration, it will try
+to find the value in the environment variables.
+
+For looking up a value in spin configuration, keys are used as is (case sensitive).
+For looking up a value in environment variables, keys are converted to uppercase.
+
+If key is neither found in Spin configuration nor in environment variables,
+an empty string is returned.
+
+Usage:
+
+	cfg := NewDefaultConfigReader()
+	value := cfg.Get("destination")
+*/
+func (c DefaultConfigReader) Get(key string) string {
+	v, err := config.Get(key)
+	if err != nil {
+		return os.Getenv(strings.ToUpper(key))
+	}
+	return v
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/fermyon/finicky-whiskers/redirect
 
 go 1.17
+
+require github.com/fermyon/spin/sdk/go v1.4.2
+
+require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/fermyon/spin/sdk/go v1.4.2 h1:4U2J2WooKptCa4zeBetKctz/DEJxv3RvGauW0bZ+e6U=
+github.com/fermyon/spin/sdk/go v1.4.2/go.mod h1:yb8lGesopgj/GwPzLPATxcOeqWZT/HjrzEFfwbztAXE=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/redirect.go
+++ b/redirect.go
@@ -1,11 +1,64 @@
 package main
 
 import (
-	"fmt"
-	"os"
+	"net/http"
+	"strconv"
+
+	spinhttp "github.com/fermyon/spin/sdk/go/http"
 )
 
+const (
+	// Default value for HTTP status code
+	DefaultStatusCode int = http.StatusFound
+	// Key for loading desired destination
+	destinationKey string = "destination"
+	// Key for loading desired HTTP status code
+	statusCodeKey string = "statuscode"
+)
+
+func init() {
+	r := NewSpinRedirect()
+	spinhttp.Handle(r.handleFunc)
+}
+
 func main() {
-	dest := os.Getenv("DESTINATION")
-	fmt.Printf("status: 302\nlocation: %s\n\n", dest)
+}
+
+// SpinRedirect is a struct that provides a handleFunc
+// for redirecting to a destination URL using configurable HTTP status code.
+type SpinRedirect struct {
+	cfg ConfigReader
+}
+
+// NewSpinRedirect returns a new SpinRedirect
+func NewSpinRedirect() SpinRedirect {
+	return SpinRedirect{
+		cfg: NewDefaultConfigReader(),
+	}
+}
+
+func (s SpinRedirect) handleFunc(w http.ResponseWriter, r *http.Request) {
+	dest := s.getDestination()
+	code := s.getStatusCode()
+
+	w.Header().Set("Location", dest)
+	w.WriteHeader(code)
+}
+
+// getDestination returns the destination URL
+// If no destination is found, an empty string is returned.
+func (s SpinRedirect) getDestination() string {
+	return s.cfg.Get(destinationKey)
+}
+
+// getStatusCode returns the HTTP status code
+// If no status code is found, or if the provided value is invalid,
+// DefaultStatusCode is returned.
+func (s SpinRedirect) getStatusCode() int {
+	str := s.cfg.Get(statusCodeKey)
+	code, err := strconv.Atoi(str)
+	if err != nil {
+		return DefaultStatusCode
+	}
+	return code
 }


### PR DESCRIPTION
This PR is a bit bigger (sorry 😄 ). 

Basically, `spin-redirect` is now a regular Spin component (no more WAGI here). Additionally, the following features were added:

- Users can specify the HTTP status code used for redirecting (default remains `302` Found)
- Configuration data is loaded either from Spin component configuration or from environment variable

This would address #3 and #2 