### PR TITLE
feat(redirect): add include_path (and trim_prefix) for wildcard redirect support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ The `spin-redirect` component can be configured to address your needs in differe
 
 The following table outlines available configuration values:
 
-| Key           | Description                                           | Default Value    |
-|---------------|-------------------------------------------------------|------------------|
-| `destination` | Where should the component redirect to                | `/`              |
-| `statuscode`  | What HTTP status code should be used when redirecting | `302`            |
+| Key            | Description                                                                                                             | Default Value |
+|----------------|-------------------------------------------------------------------------------------------------------------------------|---------------|
+| `destination`  | Where should the component redirect to                                                                                  | `/`           |
+| `statuscode`   | What HTTP status code should be used when redirecting                                                                   | `302`         |
+| `include_path` | Whether to include the original request path on the destination redirect; see [wildcard redirects](#wildcard-redirects) | `false`       |
+| `trim_prefix`  | A specific prefix portion of the original request path to trim (when `include_path` is `true`)                          |               |
 
 The `spin-redirect` component tries to look up the config value in the Spin component configuration using the keys shown in the table above (lower case). If desired key is not present, it transforms the key to upper case (e.g., `DESTINATION`) and checks environment variables.
 
@@ -72,4 +74,48 @@ statuscode="301"
 [component.trigger]
 route = "/"
 
+```
+
+### Wildcard redirects
+
+Wildcard redirects can be enabled by setting `include_path` to `true`.  In the example below,
+all requests to the application will be redirected to `/foo`, with the original request path included,
+e.g. `/bar` will redirect to `/foo/bar`, `/baz` will redirect to `/foo/baz` and so on.
+
+```toml
+spin_manifest_version = 2
+
+[application]
+name = "wildcard-redirect"
+version = "0.1.0"
+
+[[trigger.http]]
+id = "trigger-redirect-to-foo"
+component = "redirect-to-foo"
+route = "/..."
+
+[component.redirect-to-foo]
+source = "modules/redirect.wasm"
+environment = { DESTINATION = "/foo", INCLUDE_PATH = "true" }
+```
+
+A prefix portion of the original request path can be trimmed via the `trim_prefix` configuration.
+
+In this example, the `/v1/` prefix is trimmed, such that requests to `/v1/bar` will redirect to `/v2/bar` and so on.
+
+```toml
+spin_manifest_version = 2
+
+[application]
+name = "wildcard-redirect"
+version = "0.1.0"
+
+[[trigger.http]]
+id = "trigger-redirect-v1-to-v2"
+component = "redirect-v1-to-v2"
+route = "/v1/..."
+
+[component.redirect-v1-to-v2]
+source = "modules/redirect.wasm"
+environment = { DESTINATION = "/v2", INCLUDE_PATH = "true", TRIM_PREFIX = "/v1/" }
 ```


### PR DESCRIPTION
Ref https://github.com/fermyon/spin-redirect/issues/4

Thanks to @rajatjindal and @kingdonb for their reference implementation(s) mentioned in https://github.com/fermyon/spin-redirect/issues/4

If we're in favor of this general direction, I can add unit test(s).  ~~And a mention in the README~~ _edit: added_.

I lumped in the 'trim prefix' functionality both because it is immediately useful for [some work I have in flight](https://github.com/fermyon/developer/pull/1497) 😅 and it seems like it would be a natural bit of functionality that users might want after including the request path.  However, if this aspect doesn't land with reviewers and needs a rethink -- or we'd just prefer it in a separate change, I can defer to a follow-up.