### PR TITLE
ci(.github): Update build, release actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Wasmtime
         uses: bytecodealliance/actions/wasmtime/setup@v1
@@ -20,7 +20,7 @@ jobs:
           version: "31.0.0"
 
       - name: "Install Go"
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.24'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,15 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+
 jobs:
   assets:
     name: Build and release assets
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: set the release version (tag)
         run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
@@ -22,7 +25,7 @@ jobs:
           version: "31.0.0"
 
       - name: "Install Go"
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.24'
 
@@ -44,7 +47,7 @@ jobs:
           sha256sum redirect.wasm > checksums-${{ env.RELEASE_VERSION }}.txt
 
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           fail_on_unmatched_files: true
           generate_release_notes: true


### PR DESCRIPTION
Upgrade all of the actions to their latest major version

When I tested releasing this in my local fork, the `permissions: contents: write` change was required by the upgraded release action.

Ref: https://github.com/softprops/action-gh-release#permissions